### PR TITLE
feat(meteor): configure deadline for cron jobs

### DIFF
--- a/stable/meteor/Chart.yaml
+++ b/stable/meteor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.2.1
+version: 0.2.2
 description: A Helm chart for Meteor (github.com/goto/meteor)
 name: meteor
 appVersion: "v0.8.0"

--- a/stable/meteor/templates/cronjob.yaml
+++ b/stable/meteor/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 4
+      activeDeadlineSeconds: {{ .Values.jobDeadlineSeconds }}
       template:
         metadata:
           labels:

--- a/stable/meteor/values.yaml
+++ b/stable/meteor/values.yaml
@@ -12,6 +12,7 @@ secretConfig: {}
 # pass in secret names to be mounted to cronjob
 ssl_secrets: []
 
+jobDeadlineSeconds: 14400
 # sample recipe usage
 # recipes:
 #   sample-recipe.yaml: |-


### PR DESCRIPTION
The deadline defaults to 4hrs (14,400s) but can be overridden if required to be higher or lower.