### PR TITLE
fix(meteor): telegraf sidecar exit coordination

### DIFF
--- a/stable/meteor/Chart.yaml
+++ b/stable/meteor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.2.2
+version: 0.2.3
 description: A Helm chart for Meteor (github.com/goto/meteor)
 name: meteor
 appVersion: "v0.8.0"

--- a/stable/meteor/templates/cronjob.yaml
+++ b/stable/meteor/templates/cronjob.yaml
@@ -26,9 +26,17 @@ spec:
             image: "{{ required `image.repository is required` .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             command:
+            {{- if .Values.telegraf.enabled }}
+              - /bin/sh
+              - -c
+              - |
+                meteor run /opt/recipes;
+                pkill -SIGTERM telegraf
+            {{- else}}
               - meteor
               - run
               - /opt/recipes
+            {{- end }}
             volumeMounts:
               - name: "{{ include "meteor.name" . }}-volume"
                 mountPath: /opt/recipes
@@ -62,6 +70,7 @@ spec:
             volumeMounts:
               - name: telegraf-conf
                 mountPath: /etc/telegraf/
+          shareProcessNamespace: true
           {{- end }}
           restartPolicy: Never
           volumes:


### PR DESCRIPTION
### Context
- Currently if telegraf sidecar enabled, telegraf sidecar will continue to run and the job wont be completed

### Changes
- ~~Using [kubexit](https://github.com/karlkfi/kubexit) to terminate the telegraf sidecar once the meteor job is completed~~
- Using `shareProcessNamespace` so we could kill telegraf after the job completed