### PR TITLE
feat: add tolerations, affinity, volumes & volumeMounts

### DIFF
--- a/stable/firehose/Chart.yaml
+++ b/stable/firehose/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: firehose
 description: A Helm chart for deploying Firehose on Kubernetes
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.7.1

--- a/stable/firehose/README.md
+++ b/stable/firehose/README.md
@@ -93,6 +93,30 @@ The following table lists the configurable parameters of Firehose chart and thei
 | telegraf.resources.limits.memory | string | `"64Mi"` | telegraf container memory limit |
 | telegraf.resources.requests.cpu | string | `"50m"` | telegraf container cpu requests |
 | telegraf.resources.requests.memory | string | `"64Mi"` | telegraf container memory requests |
+| tolerations | list | - | List of Kubernetes [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
+| volumes | list | - | List of Kubernetes [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) |
+| volumeMounts | list | - | List of Kubernetes [volume mounts](https://kubernetes.io/docs/concepts/storage/volumes/#using-volumes) |
+| nodeAffinityMatchExpressions.requiredDuringSchedulingIgnoredDuringExecution | list | - | List of Kubernetes [node affinity match expressions](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) that are required for the pod to be scheduled on a node |
+| nodeAffinityMatchExpressions.preferredDuringSchedulingIgnoredDuringExecution | list | - | List of Kubernetes [preferred node affinity match expressions](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#preferred-during-scheduling-ignoreduringexecution) for the pod scheduling |
+| tolerations.key | string | `"key1"` | Key to be mached |
+| tolerations.operator | string | `"Equal"` | Operation to be checked |
+| tolerations.value | string | `"value1"` | Values against which operation is performed |
+| tolerations.effect | string | `"NoSchedule"` | Taint effect |
+| volumes.name | string | - | Name of the Kubernetes volume |
+| volumes.items.key | string | - | Key of the secret data |
+| volumes.items.path | string | - | Path where the secret data will be mounted |
+| volumes.secretName | string | - | Name of the Kubernetes secret |
+| volumes.defaultMode | integer | - | Default file permissions for the volume |
+| volumeMounts.name | string | - | Name of the Kubernetes volume |
+| volumeMounts.mountPath | string | - | Path within the container where the volume should be mounted |
+| nodeAffinityMatchExpressions.requiredDuringSchedulingIgnoredDuringExecution.key | string | - | Key of the node affinity match expression |
+| nodeAffinityMatchExpressions.requiredDuringSchedulingIgnoredDuringExecution.operator | string | - | Operator of the node affinity match expression |
+| nodeAffinityMatchExpressions.requiredDuringSchedulingIgnoredDuringExecution.values | list | - | List of values of the node affinity match expression |
+| nodeAffinityMatchExpressions.preferredDuringSchedulingIgnoredDuringExecution.weight | integer | - | Weight of the preferred node affinity match expression |
+| nodeAffinityMatchExpressions.preferredDuringSchedulingIgnoredDuringExecution.preference.key | string | - | Key of the preferred node affinity match expression |
+| nodeAffinityMatchExpressions.preferredDuringSchedulingIgnoredDuringExecution.preference.operator | string | - | Operator of the preferred node affinity match expression |
+| nodeAffinityMatchExpressions.preferredDuringSchedulingIgnoredDuringExecution.preference.values | list | - | List of values of the preferred node affinity match expression |
+
 ---
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/firehose/templates/deployment.yaml
+++ b/stable/firehose/templates/deployment.yaml
@@ -85,8 +85,8 @@ spec:
       - emptyDir: {}
         name: workdir
       {{- end }}
-      {{- if index .Values.taints.enabled }}
-      tolerations: {{- range $key, $value := .Values.taints.list }}
+      {{- if (gt (len .Values.tolerations) 0) }}
+      tolerations: {{- range $_, $value := .Values.tolerations }}
         -  key: {{ $value.key }}
            operator: {{ $value.operator }}
            value: {{ $value.value }}

--- a/stable/firehose/templates/deployment.yaml
+++ b/stable/firehose/templates/deployment.yaml
@@ -29,12 +29,12 @@ spec:
         name: {{ .Chart.Name }}
         image: "{{ .Values.firehose.image.repository }}:{{ .Values.firehose.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.firehose.image.pullPolicy }}
+        {{- if or (index .Values "init-firehose" "enabled") (gt (len .Values.volumeMounts) 0) }}
         volumeMounts:
         {{- if index .Values "init-firehose" "enabled" }}
         - mountPath: /work-dir
           name: workdir
         {{- end }}
-        {{- if or (gt (len .Values.volumeMounts) 0) }}
         {{- range $_, $volumeMount := .Values.volumeMounts }}
         - name: {{ $volumeMount.name}}
           mountPath: {{ $volumeMount.mountPath }}
@@ -81,6 +81,7 @@ spec:
         - mountPath: /work-dir
           name: workdir
       {{- end }}
+      {{if or (index .Values.telegraf.enabled) (index .Values "init-firehose" "enabled") (gt (len .Values.volumes) 0)}}
       volumes:
       {{- if index .Values.telegraf.enabled }}
       - configMap:
@@ -91,7 +92,6 @@ spec:
       - emptyDir: {}
         name: workdir
       {{- end }}
-      {{- if or (gt (len .Values.volumes) 0) }}
       {{- range $_, $volume := .Values.volumes }}
       - name: {{ $volume.name}}
         secretName: {{ $volume.secretName }}

--- a/stable/firehose/templates/deployment.yaml
+++ b/stable/firehose/templates/deployment.yaml
@@ -34,6 +34,12 @@ spec:
         - mountPath: /work-dir
           name: workdir
         {{- end }}
+        {{- if or (gt (len .Values.volumeMounts) 0) }}
+        {{- range $_, $volumeMount := .Values.volumeMounts }}
+        - name: {{ $volumeMount.name}}
+          mountPath: {{ $volumeMount.mountPath }}
+        {{- end}}
+        {{- end}}
         resources:
           {{- toYaml .Values.firehose.resources | nindent 12 }}
         envFrom:
@@ -85,6 +91,18 @@ spec:
       - emptyDir: {}
         name: workdir
       {{- end }}
+      {{- if or (gt (len .Values.volumes) 0) }}
+      {{- range $_, $volume := .Values.volumes }}
+      - name: {{ $volume.name}}
+        secretName: {{ $volume.secretName }}
+        defaultMode: {{ $volume.defaultMode }}
+        items: {{- range $_, $item := $volume.items }}
+          - key: {{ $item.key }}
+            path: {{ $item.path }}
+        {{- end}}
+      {{- end}}
+      {{- end}}
+
       {{- if (gt (len .Values.tolerations) 0) }}
       tolerations: {{- range $_, $toleration := .Values.tolerations }}
         - key: {{ $toleration.key }}

--- a/stable/firehose/templates/deployment.yaml
+++ b/stable/firehose/templates/deployment.yaml
@@ -93,16 +93,31 @@ spec:
           effect: {{ $toleration.effect }}
         {{- end }}
       {{- end}}
-      {{- if (gt (len .Values.affinity) 0) }}
+      {{- if or (gt (len .Values.nodeAffinitiyMatchExpressions.requiredDuringSchedulingIgnoredDuringExecution) 0) (gt (len .Values.nodeAffinitiyMatchExpressions.preferredDuringSchedulingIgnoredDuringExecution) 0) }}
       affinity:
         nodeAffinity:
+          {{- if (gt (len .Values.nodeAffinitiyMatchExpressions.requiredDuringSchedulingIgnoredDuringExecution) 0) }}
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions: {{- range $_, $expression := .Values.affinity }}
+              - matchExpressions: {{- range $_, $expression := .Values.nodeAffinitiyMatchExpressions.requiredDuringSchedulingIgnoredDuringExecution }}
                   - key: {{ $expression.key }}
                     operator: {{ $expression.operator }}
                     values: {{- range $expression.values }}
                       - {{ . }}
                     {{- end}}
+              {{- end}}
+          {{- end}}
+          {{- if (gt (len .Values.nodeAffinitiyMatchExpressions.preferredDuringSchedulingIgnoredDuringExecution) 0) }}
+          preferredDuringSchedulingIgnoredDuringExecution: {{- range $_, $expression := .Values.nodeAffinitiyMatchExpressions.preferredDuringSchedulingIgnoredDuringExecution }}
+            - weight: {{ $expression.weight}}   
+              preference:   
+                matchExpressions: {{- range $_, $pref := $expression.preference }}   
+                  - key: {{ $pref.key }}
+                    operator: {{ $pref.operator }}
+                    values: {{- range $pref.values }}
+                      - {{ . }}
+                    {{- end}}
                 {{- end}}
+          {{- end}}
+          {{- end}}
       {{- end}}

--- a/stable/firehose/templates/deployment.yaml
+++ b/stable/firehose/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
       - emptyDir: {}
         name: workdir
       {{- end }}
-      {{- if index .Values "taints" "enabled" }}
+      {{- if index .Values.taints.enabled }}
       tolerations: {{- range $key, $value := .Values.taints.list }}
         -  key: {{ $value.key }}
            operator: {{ $value.operator }}

--- a/stable/firehose/templates/deployment.yaml
+++ b/stable/firehose/templates/deployment.yaml
@@ -86,10 +86,23 @@ spec:
         name: workdir
       {{- end }}
       {{- if (gt (len .Values.tolerations) 0) }}
-      tolerations: {{- range $_, $value := .Values.tolerations }}
-        -  key: {{ $value.key }}
-           operator: {{ $value.operator }}
-           value: {{ $value.value }}
-           effect: {{ $value.effect }}
+      tolerations: {{- range $_, $toleration := .Values.tolerations }}
+        - key: {{ $toleration.key }}
+          operator: {{ $toleration.operator }}
+          value: {{ $toleration.value }}
+          effect: {{ $toleration.effect }}
         {{- end }}
+      {{- end}}
+      {{- if (gt (len .Values.affinity) 0) }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions: {{- range $_, $expression := .Values.affinity }}
+                  - key: {{ $expression.key }}
+                    operator: {{ $expression.operator }}
+                    values: {{- range $expression.values }}
+                      - {{ . }}
+                    {{- end}}
+                {{- end}}
       {{- end}}

--- a/stable/firehose/templates/deployment.yaml
+++ b/stable/firehose/templates/deployment.yaml
@@ -85,3 +85,11 @@ spec:
       - emptyDir: {}
         name: workdir
       {{- end }}
+      {{- if index .Values "taints" "enabled" }}
+      tolerations: {{- range $key, $value := .Values.taints.list }}
+        -  key: {{ $value.key }}
+           operator: {{ $value.operator }}
+           value: {{ $value.value }}
+           effect: {{ $value.effect }}
+        {{- end }}
+      {{- end}}

--- a/stable/firehose/values.yaml
+++ b/stable/firehose/values.yaml
@@ -40,7 +40,9 @@ firehose:
 
 tolerations: []
 
-affinity: []
+nodeAffinitiyMatchExpressions:
+  requiredDuringSchedulingIgnoredDuringExecution: []
+  preferredDuringSchedulingIgnoredDuringExecution: []
 
 init-firehose:
   enabled: false

--- a/stable/firehose/values.yaml
+++ b/stable/firehose/values.yaml
@@ -40,9 +40,42 @@ firehose:
 
 tolerations: []
 
+volumes: []
+
+volumeMounts: []
+
 nodeAffinitiyMatchExpressions:
-  requiredDuringSchedulingIgnoredDuringExecution: []
-  preferredDuringSchedulingIgnoredDuringExecution: []
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - key: "k1"
+    operator: "Equal"
+    values:
+      - "v11"
+      - "v12"
+  - key: "k2"
+    operator: "Equal"
+    values:
+      - "v21"
+      - "v22"
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: "1"
+    preference:
+      - key: "k1"
+        operator: "Equal"
+        values:
+          - "v001"
+          - "v002"
+      - key: "k2"
+        operator: "Equal"
+        values:
+          - "v003"
+          - "v004"
+  - weight: "2"
+    preference:
+      - key: "k3"
+        operator: "Equal"
+        values:
+          - "v005"
+          - "v005"
 
 init-firehose:
   enabled: false
@@ -54,7 +87,7 @@ init-firehose:
   args: [wget -O /work-dir/protos.jar http://proto_jar_url.jar]
 
 telegraf:
-  enabled: false
+  enabled: true
   image:
     repository: telegraf
     pullPolicy: IfNotPresent

--- a/stable/firehose/values.yaml
+++ b/stable/firehose/values.yaml
@@ -38,9 +38,7 @@ firehose:
       cpu: 200m
       memory: 512Mi
 
-taints: 
-  enabled: false
-  list: {}
+tolerations: []
 
 init-firehose:
   enabled: false

--- a/stable/firehose/values.yaml
+++ b/stable/firehose/values.yaml
@@ -45,37 +45,8 @@ volumes: []
 volumeMounts: []
 
 nodeAffinitiyMatchExpressions:
-  requiredDuringSchedulingIgnoredDuringExecution:
-  - key: "k1"
-    operator: "Equal"
-    values:
-      - "v11"
-      - "v12"
-  - key: "k2"
-    operator: "Equal"
-    values:
-      - "v21"
-      - "v22"
-  preferredDuringSchedulingIgnoredDuringExecution:
-  - weight: "1"
-    preference:
-      - key: "k1"
-        operator: "Equal"
-        values:
-          - "v001"
-          - "v002"
-      - key: "k2"
-        operator: "Equal"
-        values:
-          - "v003"
-          - "v004"
-  - weight: "2"
-    preference:
-      - key: "k3"
-        operator: "Equal"
-        values:
-          - "v005"
-          - "v005"
+  requiredDuringSchedulingIgnoredDuringExecution: []
+  preferredDuringSchedulingIgnoredDuringExecution: []
 
 init-firehose:
   enabled: false
@@ -87,7 +58,7 @@ init-firehose:
   args: [wget -O /work-dir/protos.jar http://proto_jar_url.jar]
 
 telegraf:
-  enabled: true
+  enabled: false
   image:
     repository: telegraf
     pullPolicy: IfNotPresent

--- a/stable/firehose/values.yaml
+++ b/stable/firehose/values.yaml
@@ -40,6 +40,8 @@ firehose:
 
 tolerations: []
 
+affinity: []
+
 init-firehose:
   enabled: false
   image:

--- a/stable/firehose/values.yaml
+++ b/stable/firehose/values.yaml
@@ -38,6 +38,10 @@ firehose:
       cpu: 200m
       memory: 512Mi
 
+taints: 
+  enabled: false
+  list: {}
+
 init-firehose:
   enabled: false
   image:


### PR DESCRIPTION
This shall allow adding tolerations to firehose and affinity pods.

In firehose values.yaml, you can add the following at the root level

```
tolerations:
  - key: "k1"
    operator: "Equal"
    value: "v1"
    effect: "NoSchedule"

nodeAffinitiyMatchExpressions:
  requiredDuringSchedulingIgnoredDuringExecution:
  - key: "k1"
    operator: "Equal"
    values:
      - "v11"
      - "v12"
  - key: "k2"
    operator: "Equal"
    values:
      - "v21"
      - "v22"
  preferredDuringSchedulingIgnoredDuringExecution:
  - weight: "1"
    preference:
      - key: "k1"
        operator: "Equal"
        values:
          - "v001"
          - "v002"
      - key: "k2"
        operator: "Equal"
        values:
          - "v003"
          - "v004"
  - weight: "2"
    preference:
      - key: "k3"
        operator: "Equal"
        values:
          - "v005"
          - "v005"
```

And it shall generate 

```
# Source: firehose/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: deployment.yaml-firehose
  namespace: default
  labels:
    application: firehose
spec:
  replicas: 1
  selector:
    matchLabels:
      app: deployment.yaml-firehose
  template:
    metadata:
      annotations:
        checksum/config: cfa35c246f70b4c1cf0ac0a2b44229ef407f42173d7f8c9c3efd4951267a6315
      labels:
        app: deployment.yaml-firehose
        application: firehose
    spec:
      containers:
      - args:
        - java
        - -cp
        - bin/*:/work-dir/*
        - com.gotocompany.firehose.launch.Main
        - -server
        - -Dlogback.configurationFile=etc/firehose/logback.xml
        - -Xloggc:/var/log/firehose
        name: firehose
        image: "gotocompany/firehose:1.1.0"
        imagePullPolicy: IfNotPresent
        volumeMounts:
        resources:
            limits:
              cpu: 200m
              memory: 512Mi
            requests:
              cpu: 200m
              memory: 512Mi
        envFrom:
          - configMapRef:
              name: deployment.yaml-firehose-config
        env:
        - name: POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
      volumes:
      tolerations:
        - key: k1
          operator: Equal
          value: v1
          effect: NoSchedule
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: k1
                    operator: Equal
                    values:
                      - v11
                      - v12
                  - key: k2
                    operator: Equal
                    values:
                      - v21
                      - v22
          preferredDuringSchedulingIgnoredDuringExecution:
            - weight: 1   
              preference:   
                matchExpressions:   
                  - key: k1
                    operator: Equal
                    values:
                      - v001
                      - v002   
                  - key: k2
                    operator: Equal
                    values:
                      - v003
                      - v004
            - weight: 2   
              preference:   
                matchExpressions:   
                  - key: k3
                    operator: Equal
                    values:
                      - v005
                      - v005
```

Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
