### PR TITLE
feat(siren): update app chart version

### DIFF
--- a/stable/siren/Chart.yaml
+++ b/stable/siren/Chart.yaml
@@ -2,21 +2,21 @@ apiVersion: v2
 name: siren
 description: Siren Helm chart
 version: 0.1.2
-appVersion: v0.5.1
+appVersion: v0.5.2
 home: https://github.com/goto/siren
 dependencies:
 - name: app
-  version: "0.5.1"
+  version: "0.5.2"
   repository: "https://goto.github.io/charts/"
   alias: app
   condition: app.enabled
 - name: app
-  version: "0.5.1"
+  version: "0.5.2"
   repository: "https://goto.github.io/charts/"
   alias: notification-worker
   condition: notification-worker.enabled
 - name: app
-  version: "0.5.1"
+  version: "0.5.2"
   repository: "https://goto.github.io/charts/"
   alias: notification-dlq-worker
   condition: notification-dlq-worker.enabled

--- a/stable/siren/Chart.yaml
+++ b/stable/siren/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: siren
 description: Siren Helm chart
-version: 0.1.2
-appVersion: v0.5.2
+version: 0.1.3
+appVersion: v0.6.1
 home: https://github.com/goto/siren
 dependencies:
 - name: app

--- a/stable/siren/Chart.yaml
+++ b/stable/siren/Chart.yaml
@@ -2,21 +2,21 @@ apiVersion: v2
 name: siren
 description: Siren Helm chart
 version: 0.1.2
-appVersion: v0.5.0
+appVersion: v0.5.1
 home: https://github.com/goto/siren
 dependencies:
 - name: app
-  version: "0.4.3"
-  repository: "https://goto.github.io/charts-legacy/"
+  version: "0.5.1"
+  repository: "https://goto.github.io/charts/"
   alias: app
   condition: app.enabled
 - name: app
-  version: "0.4.3"
-  repository: "https://goto.github.io/charts-legacy/"
+  version: "0.5.1"
+  repository: "https://goto.github.io/charts/"
   alias: notification-worker
   condition: notification-worker.enabled
 - name: app
-  version: "0.4.3"
-  repository: "https://goto.github.io/charts-legacy/"
+  version: "0.5.1"
+  repository: "https://goto.github.io/charts/"
   alias: notification-dlq-worker
   condition: notification-dlq-worker.enabled

--- a/stable/siren/values.yaml
+++ b/stable/siren/values.yaml
@@ -15,6 +15,7 @@ app:
       httpGet:
         path: /ping
         port: tcp
+  podLabels: {}
 
   migration:
     enabled: true


### PR DESCRIPTION
This PR should allow siren chart to use the latest app chart dependency to add pod labels.