### PR TITLE
feat(siren): add podLabels value in workers

### DIFF
--- a/stable/siren/Chart.yaml
+++ b/stable/siren/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: siren
 description: Siren Helm chart
-version: 0.1.3
-appVersion: v0.6.1
+version: 0.1.4
+appVersion: v0.6.2
 home: https://github.com/goto/siren
 dependencies:
 - name: app

--- a/stable/siren/values.yaml
+++ b/stable/siren/values.yaml
@@ -72,6 +72,7 @@ notification-worker:
         - ps -ef | grep siren | grep -v grep
       initialDelaySeconds: 10
       periodSeconds: 10
+  podLabels: {}
 
   migration:
     enabled: false
@@ -115,6 +116,7 @@ notification-dlq-worker:
         - ps -ef | grep siren | grep -v grep
       initialDelaySeconds: 10
       periodSeconds: 10
+  podLabels: {}
 
   migration:
     enabled: false


### PR DESCRIPTION
This PR should allow podLabels value addition to siren notification-dlq-worker and notification-worker.