### PR TITLE
fix: Optimus db cleanup cron job

### DIFF
--- a/stable/optimus/Chart.yaml
+++ b/stable/optimus/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/optimus/templates/data-cleanup-cronjob.yaml
+++ b/stable/optimus/templates/data-cleanup-cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cleanupConfig.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "app.fullname" . }}-cleanup


### PR DESCRIPTION
the CronJob resource is already in stable GA version since 1.21 https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/ 