### PR TITLE
feat(compass): deprecated APIs removed in 1.25

### DIFF
--- a/stable/meteor/Chart.yaml
+++ b/stable/meteor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.2.3
+version: 0.3.0
 description: A Helm chart for Meteor (github.com/goto/meteor)
 name: meteor
 appVersion: "v0.8.0"

--- a/stable/meteor/templates/cronjob.yaml
+++ b/stable/meteor/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "{{ include "meteor.name" . }}"


### PR DESCRIPTION
### Changes

- replace `batch/v1beta1` to `batch/v1`