### PR TITLE
feat(app): introduce hpa

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.6
+version: 0.6.0

--- a/stable/app/templates/hpa.yaml
+++ b/stable/app/templates/hpa.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.hpa.enabled }}
+{{- $fullName := include "app.fullname" . -}}
+{{- $appLabels := include "app.labels" . -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- $appLabels | nindent 4 }}
+spec:
+  minReplicas: {{ .Values.hpa.replicas.min }}
+  maxReplicas: {{ .Values.hpa.replicas.max }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $fullName }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.hpa.stabilizationWindowSeconds.scaleDown }}
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.hpa.stabilizationWindowSeconds.scaleUp }}
+  metrics:
+    {{- if .Values.hpa.targetUtilization.memory }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetUtilization.memory }}
+    {{- end }}
+    {{- if .Values.hpa.targetUtilization.cpu }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetUtilization.cpu }}
+    {{- end }}
+---
+{{- end -}}

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -125,6 +125,18 @@ container:
 #       path: auth.json
 #     secretName: app-service-account
 
+hpa:
+  enabled: false
+  targetUtilization: 
+    cpu: 70
+    memory: 70
+  stabilizationWindowSeconds:
+    scaleDown: 300
+    scaleUp: 0
+  replicas:
+    min: 1
+    max: 1
+
 config: {}
 
 secretConfig:


### PR DESCRIPTION
### Changes

- Add HPA capabilities to app charts to enable scaling for deployment by utilization. [Read more here](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
- Non-breaking changes, disabled by default.