### PR TITLE
fix: change command to arg

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.4
+version: 0.5.5

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -75,9 +75,9 @@ spec:
         {{- if .Values.otelcollector.enabled }}
         - name: otel-collector-sidecar
           image: {{ .Values.otelcollector.image }}
-          command:
-            - "--config=/etc/otelcollector/config.yaml"
           imagePullPolicy: IfNotPresent
+          args:
+            - "--config=/etc/otelcollector/config.yaml"
           ports:
           - containerPort: 1888
             name: pprof


### PR DESCRIPTION
changes `command` to `args` for passing config file path for the otel-collector container.