### PR TITLE
feat(dex): update use app chart 0.1.3

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: dex
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
-appVersion: 0.1.1
+version: 0.1.3
+appVersion: 0.7.11
 dependencies:
 - name: app
-  version: "0.5.6"
+  version: "0.5.7"
   repository: "https://goto.github.io/charts/"

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -19,6 +19,8 @@ app:
         port: tcp
   podLabels: {}
 
+  serviceAccountName: ""
+
   migration:
     enabled: false
 


### PR DESCRIPTION
update dex chart to use `app` chart version `0.1.3` to assign service account to deployment.