### PR TITLE
chore(guardian): remove optional field from secret config

### DIFF
--- a/stable/guardian/Chart.yaml
+++ b/stable/guardian/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/guardian/values.yaml
+++ b/stable/guardian/values.yaml
@@ -89,7 +89,6 @@ app:
 
   secretConfig:
     ENCRYPTION_SECRET_KEY:
-    NOTIFIER_ACCESS_TOKEN:
     DB_HOST: localhost
     DB_PORT:
     DB_NAME: guardian


### PR DESCRIPTION
If we keep the field here empty as is, it will be present in the k8s secrets as `NOTIFIER_ACCESS_TOKEN=<nil>`, if we are not setting it at deployment level. The field itself is optional in guardian.





