### PR TITLE
feat: omit default resource limits for telegeaf

### DIFF
--- a/stable/firehose/Chart.yaml
+++ b/stable/firehose/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: firehose
 description: A Helm chart for deploying Firehose on Kubernetes
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: 0.7.1

--- a/stable/firehose/values.yaml
+++ b/stable/firehose/values.yaml
@@ -77,13 +77,7 @@ telegraf:
         url: "http://localhost:8088"
         version: "0.1.0"
         # authorization: Bearer <token>
-  resources:
-    limits:
-      cpu: 50m
-      memory: 64Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
+  resources: {}
 
 envSecrets: {}
 mountSecrets: []


### PR DESCRIPTION
The current limits were very small and firehoses were failing with OEM. Removing the default values from the chart.