### PR TITLE
feat(app): add otelcollector healthcheck

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.10
+version: 0.5.11

--- a/stable/app/templates/deployment.yaml
+++ b/stable/app/templates/deployment.yaml
@@ -132,6 +132,18 @@ spec:
           volumeMounts:
             - name: otelcollector-conf
               mountPath: /etc/otelcollector/
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 13133
+            initialDelaySeconds: {{ .Values.otelcollector.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.otelcollector.readinessProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 13133
+            initialDelaySeconds: {{ .Values.otelcollector.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.otelcollector.livenessProbe.periodSeconds }}
         {{- end }}
         {{- if .Values.telegraf.enabled }}
         - name: telegraf-sidecar

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -152,7 +152,13 @@ telegraf:
 
 otelcollector:
   enabled: false
-  image: otel/opentelemetry-collector-contrib:0.79.0
+  image: otel/opentelemetry-collector-contrib:0.89.0
+  readinessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 5
+  livenessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 5
   config: |
     receivers:
       otlp:


### PR DESCRIPTION
### Background:
Currently, the otelcollector sidecar does not have readiness and liveness checks, which can result in missing metrics if the sidecar is in an unhealthy state.

### Changes:
This PR adds readiness and liveness checks for the otelcollector sidecar, ensuring that the sidecar is properly monitored and prevents any disruption in metric collection and bump the default image to the latest version `0.89.0`
