### PR TITLE
fix(optimus): update cron job to limit the history and to add label

### DIFF
--- a/stable/optimus/Chart.yaml
+++ b/stable/optimus/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stable/optimus/templates/data-cleanup-cronjob.yaml
+++ b/stable/optimus/templates/data-cleanup-cronjob.yaml
@@ -8,9 +8,13 @@ metadata:
 spec:
   schedule: {{ .Values.cleanupConfig.schedule }}
   concurrencyPolicy: {{ .Values.cleanupConfig.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.cleanupConfig.successJobHistoryLimit }}
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{- include "app.labels" . | nindent 12 }}
         spec:
           containers:
           - name: {{ include "app.fullname" . }}-cleanup

--- a/stable/optimus/values.yaml
+++ b/stable/optimus/values.yaml
@@ -79,6 +79,7 @@ cleanupConfig:
   image: "postgres:15.2-alpine3.17"
   restartPolicy: OnFailure
   concurrencyPolicy: Forbid
+  successJobHistoryLimit: 1
   queries:
     - "delete from sensor_run where start_time < now() - Interval '5 months';"
     - "delete from task_run   where start_time < now() - Interval '5 months';"


### PR DESCRIPTION
This PR is to update Optimus chart to address:
* labels not visible in the cron job
* limiting the number of success cron job history