### PR TITLE
feat: making additional ingress optional in app

### DIFF
--- a/stable/app/Chart.yaml
+++ b/stable/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1

--- a/stable/app/values.yaml
+++ b/stable/app/values.yaml
@@ -68,21 +68,6 @@ ingress:
   # --  - secretName: chart-example-tls
   # --    hosts:
   # --      - chart-example.local
-  additionalIngress:
-  - name: grpc
-    className: ""
-    annotations: {}
-    hosts:
-      - host: grpc-chart-example.local
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                # name: backend_01
-                port:
-                  number: 8081
-            tls: [] 
 
 resources:
   {}


### PR DESCRIPTION
- removing additional ingress in app values yaml to make it optional
- the chart that depends on app needs to define the additional ingress by itself