### PR TITLE
feat: capability in meteor to configure service account with token volume projection

### DIFF
--- a/stable/meteor/Chart.yaml
+++ b/stable/meteor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.3.2
+version: 0.3.3
 description: A Helm chart for Meteor (github.com/goto/meteor)
 name: meteor
 appVersion: "v0.8.9"

--- a/stable/meteor/templates/cronjob.yaml
+++ b/stable/meteor/templates/cronjob.yaml
@@ -21,6 +21,9 @@ spec:
 {{ toYaml .Values.labels | indent 12 }}
 {{- end }}
         spec:
+          {{- if .Values.serviceAccount.name }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
           containers:
           - name: "{{ include "meteor.name" . }}"
             image: "{{ required `image.repository is required` .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -43,6 +46,10 @@ spec:
               - name: {{ $v }}
                 mountPath: {{ printf "%s/%s" "/etc/secret" $v }}
               {{- end }}
+              {{- if .Values.serviceAccount.volumeProjection.enabled }}
+              - name: {{ .Values.serviceAccount.volumeProjection.name }}
+                mountPath: {{ .Values.serviceAccount.volumeProjection.mountPath }}
+              {{- end}}
             envFrom:
               - configMapRef:
                   name: "{{ include "meteor.name" . }}-variables-configmap"
@@ -154,3 +161,12 @@ spec:
               configMap:
                 name: {{ include "meteor.name" . }}-otelcollector
           {{- end }}
+          {{- if .Values.serviceAccount.volumeProjection.enabled }}
+              - name: {{ .Values.serviceAccount.volumeProjection.name }}
+                projected:
+                  sources:
+                    - serviceAccountToken:
+                        path: {{ .Values.serviceAccount.volumeProjection.name }}
+                        expirtationSeconds: {{ .Values.serviceAccount.volumeProjection.expirationSeconds }}
+                        audience: {{ .Values.serviceAccount.volumeProjection.audience }}
+          {{- end}}

--- a/stable/meteor/templates/cronjob.yaml
+++ b/stable/meteor/templates/cronjob.yaml
@@ -22,7 +22,7 @@ spec:
 {{- end }}
         spec:
           {{- if .Values.serviceAccount.name }}
-          serviceAccountName: {{ .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccount.name }}
           {{- end }}
           containers:
           - name: "{{ include "meteor.name" . }}"
@@ -46,9 +46,9 @@ spec:
               - name: {{ $v }}
                 mountPath: {{ printf "%s/%s" "/etc/secret" $v }}
               {{- end }}
-              {{- if .Values.serviceAccount.volumeProjection.enabled }}
-              - name: {{ .Values.serviceAccount.volumeProjection.name }}
-                mountPath: {{ .Values.serviceAccount.volumeProjection.mountPath }}
+              {{- if .Values.serviceAccount.tokenProjection.enabled }}
+              - name: {{ .Values.serviceAccount.name }}
+                mountPath: {{ .Values.serviceAccount.tokenProjection.mountPath }}
               {{- end}}
             envFrom:
               - configMapRef:
@@ -161,12 +161,12 @@ spec:
               configMap:
                 name: {{ include "meteor.name" . }}-otelcollector
           {{- end }}
-          {{- if .Values.serviceAccount.volumeProjection.enabled }}
-              - name: {{ .Values.serviceAccount.volumeProjection.name }}
-                projected:
-                  sources:
-                    - serviceAccountToken:
-                        path: {{ .Values.serviceAccount.volumeProjection.name }}
-                        expirtationSeconds: {{ .Values.serviceAccount.volumeProjection.expirationSeconds }}
-                        audience: {{ .Values.serviceAccount.volumeProjection.audience }}
+          {{- if .Values.serviceAccount.tokenProjection.enabled }}
+            - name: {{ .Values.serviceAccount.name }}
+              projected:
+                sources:
+                  - serviceAccountToken:
+                      path: {{ .Values.serviceAccount.tokenProjection.subPath }}
+                      expirtationSeconds: {{ .Values.serviceAccount.tokenProjection.expirationSeconds }}
+                      audience: {{ .Values.serviceAccount.tokenProjection.audience }}
           {{- end}}

--- a/stable/meteor/templates/cronjob.yaml
+++ b/stable/meteor/templates/cronjob.yaml
@@ -167,6 +167,6 @@ spec:
                 sources:
                   - serviceAccountToken:
                       path: {{ .Values.serviceAccount.tokenProjection.subPath }}
-                      expirtationSeconds: {{ .Values.serviceAccount.tokenProjection.expirationSeconds }}
+                      expirationSeconds: {{ .Values.serviceAccount.tokenProjection.expirationSeconds }}
                       audience: {{ .Values.serviceAccount.tokenProjection.audience }}
           {{- end}}

--- a/stable/meteor/values.yaml
+++ b/stable/meteor/values.yaml
@@ -71,6 +71,7 @@ serviceAccount:
   name: ""
   tokenProjection:
     enabled: false
-    mountPath: "/var/run/secrets/tokens"
+    mountPath: "/var/run/secrets"
+    subPath: "token"
     expirationSeconds: 600
     audience: ""

--- a/stable/meteor/values.yaml
+++ b/stable/meteor/values.yaml
@@ -66,3 +66,11 @@ otelcollector:
           receivers: [otlp]
           processors: []
           exporters: [logging]
+
+serviceAccount:
+  name: ""
+  tokenProjection:
+    enabled: false
+    mountPath: "/var/run/secrets/tokens"
+    expirationSeconds: 600
+    audience: ""


### PR DESCRIPTION
- This feature adds capability to configure service account to Pods. This allows the meteor pods to run with workload identity.
- It also allows the service account token volume projection [ref](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#serviceaccount-token-volume-projection) which will autorotate the kubernetes token in the pods mountPath based on the configured expiry
  Example use-case: We are planning to use this token for one of our Kafka which use `SASL_OAUTHBEARER` mechanism
