### PR TITLE
feat(entropy): update app chart dependency to v0.6.0

### DIFF
--- a/stable/entropy/Chart.yaml
+++ b/stable/entropy/Chart.yaml
@@ -2,16 +2,16 @@ apiVersion: v2
 name: entropy
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: 0.1.26
 dependencies:
 - name: app
-  version: "0.5.12"
+  version: "0.6.0"
   repository: "https://goto.github.io/charts/"
   alias: app
   condition: app.enabled
 - name: app
-  version: "0.5.12"
+  version: "0.6.0"
   repository: "https://goto.github.io/charts/"
   alias: worker
   condition: worker.enabled


### PR DESCRIPTION
use app chart 0.6.0 in entropy