### PR TITLE
feat: add service account and acl configuration for acl enabled kafka

### DIFF
--- a/stable/dagger/Chart.yaml
+++ b/stable/dagger/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: dagger-deployment-chart
 description: A Helm chart for dagger deployment
 type: application
-version: 0.9.3
+version: 0.9.4
 appVersion: "1.0"

--- a/stable/dagger/Chart.yaml
+++ b/stable/dagger/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: dagger-deployment-chart
 description: A Helm chart for dagger deployment
 type: application
-version: 0.9.4
+version: 0.9.4-rc1
 appVersion: "1.0"

--- a/stable/dagger/templates/dagger.yaml
+++ b/stable/dagger/templates/dagger.yaml
@@ -53,6 +53,9 @@ spec:
     metrics.scope.tm.job: taskmanager-job.godata-id-flink-operator.<tm_id>.<job_name>
     metrics.scope.task: task.godata-id-flink-operator.<tm_id>.<job_name>.<task_name>.<subtask_index>
     metrics.scope.operator: operator.godata-id-flink-operator.<tm_id>.<job_name>.<subtask_index>
+    {{- if .Values.kubernetes_taskmanager_service_account }}
+    kubernetes.taskmanager.service-account: {{ .Values.kubernetes_taskmanager_service_account }}
+    {{- end }}
   serviceAccount: flink
   podTemplate:
     apiVersion: v1
@@ -86,6 +89,10 @@ spec:
           {{- if eq .Values.cloud_provider "gcp" }}
             - mountPath: /var/secrets/google
               name: google-cloud-key
+          {{- end}}
+          {{- range $_, $mount := .Values.acl_mounts }}
+            - mountPath: {{ $mount.mountPath }}
+              name: {{ $mount.name }}
           {{- end}}
         - name: telegrafd
           image: telegraf:1.18.3-alpine
@@ -125,6 +132,23 @@ spec:
           secret:
             defaultMode: 420
             secretName: flink-operator-gcp
+        {{- end}}
+        {{- range $_, $mount := .Values.acl_mounts }}
+        - name: {{ $mount.name }}
+          {{- if eq $mount.type "secret" }}
+          secret:
+            defaultMode: 420
+            secretName: {{ $mount.secretName }}
+          {{- end }}
+          {{- if eq $mount.type "projected" }}
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  audience: kafka
+                  expirationSeconds: 600
+                  path: token
+          {{- end }}
         {{- end}}
       {{- if (gt (len .Values.tolerations) 0) }}
       

--- a/stable/dagger/values.yaml
+++ b/stable/dagger/values.yaml
@@ -26,6 +26,11 @@ savepointTriggerNonce: 1
 urn: "dagger:urn"
 fs_oss_endpoint: "oss-ap-southeast-5-internal.aliyuncs.com"
 
+# ACL (SASL/SSL) Kafka source support. Populated by Entropy for ACL streams;
+# empty by default so plaintext daggers render an unchanged podTemplate.
+acl_mounts: []
+kubernetes_taskmanager_service_account: ""
+
 tolerations: []
 
 nodeAffinityMatchExpressions:


### PR DESCRIPTION
## Description

This PR adds support for service account and ACL configuration when connecting to ACL-enabled Kafka clusters.

## Changes

- Added configuration for Kafka service accounts.
- Added support for Kafka ACL-related settings.
- Updated the deployment/configuration flow to pass the required authentication and authorization details for ACL-enabled Kafka clusters.
- Maintains backward compatibility for Kafka clusters that do not require ACLs.